### PR TITLE
Adding `truncation` request parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,6 @@ Example of running multiple tasks to stage items needed to run Triton Server
 task build-execution-env-all
 task model-import
 task triton-start
-# Tail logs of running containr
+# Tail logs of running container
 docker logs -f $(docker ps -q --filter "name=triton-inference-server")
 ```

--- a/docs/e5_large_v2.md
+++ b/docs/e5_large_v2.md
@@ -26,6 +26,12 @@ separately.
 This is a lower level of abstraction, most clients likely should be using
 [embed_text](embed_text.md) deployment.
 
+Optional Request Parameters:
+* `truncation`: bool, optional, default=False
+  Set to true if you want to truncate provided text to maximum length (512 tokens)
+  supported by the model. Otherwise, if the provided text is too many tokens, an error
+  will be returned.
+
 ## Example Request
 Here's an example request. Just a few things to point out
 1. "shape": [1, 1] because we have dynamic batching and the first axis is

--- a/docs/e5_large_v2.md
+++ b/docs/e5_large_v2.md
@@ -27,10 +27,16 @@ This is a lower level of abstraction, most clients likely should be using
 [embed_text](embed_text.md) deployment.
 
 Optional Request Parameters:
-* `truncation`: bool, optional, default=False
-  Set to true if you want to truncate provided text to maximum length (512 tokens)
-  supported by the model. Otherwise, if the provided text is too many tokens, an error
-  will be returned.
+* `truncation`: str | bool, optional, default=False
+  Passed along to Huggingface tokenizer class. See [tokenizer docs](https://huggingface.co/docs/transformers/main_classes/tokenizer#transformers.PreTrainedTokenizer.__call__) for more details. Mostly likely
+  value will be `True` which truncates the provided text to the maximum length of
+  tokens supported by the model. Otherwise, if the provided text is too many tokens,
+  an error will be returned. Acceptable values for current tokenizer class are:
+    * True or 'longest_first'
+    * 'only_first'
+    * 'only_second'
+    * False or 'do_not_truncate'
+
 
 ## Example Request
 Here's an example request. Just a few things to point out

--- a/docs/embed_text.md
+++ b/docs/embed_text.md
@@ -14,9 +14,15 @@ Optional Request Parameters:
 * `embed_model`: str, optional, default="multilingual_e5_large"
   Specify which embedding model to use. Choices are `multilingual_e5_large`,
   `siglip_text`, or `e5_large_v2`
-* `truncation`: bool, optional, default=False
-  Set to true if you want to truncate provided text to maximum length supported by the
-  model. Otherwise, if the provided text is too many tokens, an error will be returned.
+* `truncation`: str | bool, optional, default=False
+  Passed along to Huggingface tokenizer class. See [tokenizer docs](https://huggingface.co/docs/transformers/main_classes/tokenizer#transformers.PreTrainedTokenizer.__call__) for more details. Mostly likely
+  value will be `True` which truncates the provided text to the maximum length of
+  tokens supported by the model. Otherwise, if the provided text is too many tokens,
+  an error will be returned. Acceptable values for current tokenizer class are:
+    * True or 'longest_first'
+    * 'only_first'
+    * 'only_second'
+    * False or 'do_not_truncate'
 
 ## Multilingual E5 Text Embeddings
 For optimal performance, all text sent must have either "query: " or "passage: "
@@ -71,7 +77,15 @@ response_json = text_embed_response.json()
 text_embedding = np.array(response_json["outputs"][0]["data"]).astype(np.float32)
 
 # Try using longer text but with truncation request parameter
-text = 50*text
+text = """query: 
+In the year 2075, Paris was a city of neon and steel, where the air was thick with the hum of drones and the smell of ozone. The once-great Seine was now a channel of neon, illuminated by the advertisements that never stopped flashing, even in the dead of night. The Eiffel Tower, still standing as a testament to an era long gone, was now a behemoth of corporate logos, each vying for the attention of the passing crowds.
+
+The streets below were a labyrinth of shadows, where the remnants of humanity huddled in the remnants of humanity, where the remnants of humanity huddled in the shadows. The elite lived in sky cities, where they had never known the harsh reality of the ground below, where the poor lived out their days in squalor, trying to make ends meet in a society that had all but forgotten them. The only thing that ever changed was the weather, which was a constant battle between the corporations and the planet. The Parisian air was thick with pollution and the smell of ozone. The air was thick with pollution and the smell of ozone.
+
+The city was ruled by an uneasy alliance of corporations and their private armies. The police were more like enforcers, taking bribes and looking the other way while the corporations did whatever they pleased. It was a world where the only law was the law of the jungle, where the strong preyed on the weak, and where the weak were left to fend for themselves. And yet, amidst this chaos, there were those who dared to challenge the status quo, who fought for a better future. One such group was the Netrunners, who used their hacking skills to take down the corporations from the shadows. They were a constant thorn in the side of the ruling elite, and they were not going to stop anytime soon. This night was no different. In the shadows of the old Montmartre district, a lone figure darted through the alleys, cloak billowing behind them. The figure, known as Phantom, was a notorious Netrunner, and tonight, they had a job to do. Their target was one of the most powerful corporations in the city, and their mission was to expose the dark secrets hidden within the corporate mainframe.
+
+Phantom moved swiftly and silently, their augmented reality glasses guiding them through the maze of back alleys and abandoned buildings. The city's underbelly was a dangerous place, filled with the desperate and the depraved, but Phantom knew how to navigate its treacherous paths. As they approached their destination, the holographic advertisements flickered and warped, creating a dizzying display of light and color. Phantom paused for a moment, taking in the scene before them. The corporation's headquarters loomed ahead, a towering monolith of steel and glass, its surface adorned with the ever-shifting logos of its many subsidiaries. Phantom took a deep breath, steeling themselves for the challenge ahead. They knew the stakes were high, but they also knew that the fight for justice was worth any risk. With a final nod of determination, Phantom stepped into the shadows and began their ascent to the top of the corporate fortress.
+"""
 inference_json = {
     "parameters": {"truncation": True},
     "inputs": [

--- a/docs/embed_text.md
+++ b/docs/embed_text.md
@@ -12,8 +12,11 @@ addition, this allows for controlling the GPU RAM consumed by the server.
 
 Optional Request Parameters:
 * `embed_model`: str, optional, default="multilingual_e5_large"
-  Specify which embedding model to use. Choices are `multilingual_e5_large` or
-  `siglip_text`.
+  Specify which embedding model to use. Choices are `multilingual_e5_large`,
+  `siglip_text`, or `e5_large_v2`
+* `truncation`: bool, optional, default=False
+  Set to true if you want to truncate provided text to maximum length supported by the
+  model. Otherwise, if the provided text is too many tokens, an error will be returned.
 
 ## Multilingual E5 Text Embeddings
 For optimal performance, all text sent must have either "query: " or "passage: "
@@ -65,6 +68,27 @@ response_json = text_embed_response.json()
     ]
 }
 """
+text_embedding = np.array(response_json["outputs"][0]["data"]).astype(np.float32)
+
+# Try using longer text but with truncation request parameter
+text = 50*text
+inference_json = {
+    "parameters": {"truncation": True},
+    "inputs": [
+        {
+            "name": "INPUT_TEXT",
+            "shape": [1, 1],
+            "datatype": "BYTES",
+            "data": [text],
+        }
+    ]
+}
+text_embed_response = requests.post(
+    url=f"{base_url}/embed_text/infer",
+    json=inference_json,
+)
+
+response_json = text_embed_response.json()
 text_embedding = np.array(response_json["outputs"][0]["data"]).astype(np.float32)
 ```
 

--- a/docs/multilingual_e5_large.md
+++ b/docs/multilingual_e5_large.md
@@ -27,10 +27,15 @@ This is a lower level of abstraction, most clients likely should be using
 [embed_text](embed_text.md) deployment.
 
 Optional Request Parameters:
-* `truncation`: bool, optional, default=False
-  Set to true if you want to truncate provided text to maximum length (512 tokens)
-  supported by the model. Otherwise, if the provided text is too many tokens, an error
-  will be returned.
+* `truncation`: str | bool, optional, default=False
+  Passed along to Huggingface tokenizer class. See [tokenizer docs](https://huggingface.co/docs/transformers/main_classes/tokenizer#transformers.PreTrainedTokenizer.__call__) for more details. Mostly likely
+  value will be `True` which truncates the provided text to the maximum length of
+  tokens supported by the model. Otherwise, if the provided text is too many tokens,
+  an error will be returned. Acceptable values for current tokenizer class are:
+    * True or 'longest_first'
+    * 'only_first'
+    * 'only_second'
+    * False or 'do_not_truncate'
 
 ## Example Request
 Here's an example request. Just a few things to point out

--- a/docs/multilingual_e5_large.md
+++ b/docs/multilingual_e5_large.md
@@ -26,6 +26,12 @@ separately.
 This is a lower level of abstraction, most clients likely should be using
 [embed_text](embed_text.md) deployment.
 
+Optional Request Parameters:
+* `truncation`: bool, optional, default=False
+  Set to true if you want to truncate provided text to maximum length (512 tokens)
+  supported by the model. Otherwise, if the provided text is too many tokens, an error
+  will be returned.
+
 ## Example Request
 Here's an example request. Just a few things to point out
 1. "shape": [1, 1] because we have dynamic batching and the first axis is

--- a/docs/siglip_text.md
+++ b/docs/siglip_text.md
@@ -16,6 +16,12 @@ string of text to be embedded.
 This is a lower level of abstraction, most clients likely should be using
 [embed_text](embed_text.md) deployment.
 
+Optional Request Parameters:
+* `truncation`: bool, optional, default=False
+  Set to true if you want to truncate provided text to maximum length (64 tokens)
+  supported by the model. Otherwise, if the provided text is too many tokens, an error
+  will be returned.
+
 ## Example Request
 Here's an example request. Just a few things to point out
 1. "shape": [1, 1] because we have dynamic batching and the first axis is

--- a/docs/siglip_text.md
+++ b/docs/siglip_text.md
@@ -17,10 +17,15 @@ This is a lower level of abstraction, most clients likely should be using
 [embed_text](embed_text.md) deployment.
 
 Optional Request Parameters:
-* `truncation`: bool, optional, default=False
-  Set to true if you want to truncate provided text to maximum length (64 tokens)
-  supported by the model. Otherwise, if the provided text is too many tokens, an error
-  will be returned.
+* `truncation`: str | bool, optional, default=False
+  Passed along to Huggingface tokenizer class. See [tokenizer docs](https://huggingface.co/docs/transformers/main_classes/tokenizer#transformers.PreTrainedTokenizer.__call__) for more details. Mostly likely
+  value will be `True` which truncates the provided text to the maximum length of
+  tokens supported by the model. Otherwise, if the provided text is too many tokens,
+  an error will be returned. Acceptable values for current tokenizer class are:
+    * True or 'longest_first'
+    * 'only_first'
+    * 'only_second'
+    * False or 'do_not_truncate'
 
 ## Example Request
 Here's an example request. Just a few things to point out

--- a/model-repository/e5_large_v2_tokenize/1/e5_large_v2_tokenize.py
+++ b/model-repository/e5_large_v2_tokenize/1/e5_large_v2_tokenize.py
@@ -1,3 +1,4 @@
+import json
 import numpy as np
 from transformers import AutoTokenizer
 
@@ -19,6 +20,21 @@ class TritonPythonModel:
         args : dict
             Command-line arguments for launching Triton Inference Server
         """
+        self.model_config = model_config = json.loads(args["model_config"])
+
+        # Specify the default truncate value. Can be overridden in request parameter
+        default_truncation = model_config["parameters"]["default_truncation"][
+            "string_value"
+        ]
+        if default_truncation in ["False", "false"]:
+            self.default_truncation = False
+        elif default_truncation in ["True", "true"]:
+            self.default_truncation = True
+        else:
+            raise ValueError(
+                f"{default_truncation=:} must be 'true' | 'True' | 'false' | 'False'"
+            )
+
         self.tokenizer = AutoTokenizer.from_pretrained(
             "intfloat/e5-large-v2", local_files_only=True
         )
@@ -42,6 +58,12 @@ class TritonPythonModel:
         except Exception as exc:
             raise ValueError(f"Failed on getting input tensor from request: {exc}")
 
+        # Handle any request parameters
+        request_params = json.loads(request.parameters())
+        truncation = request_params.get("truncation", self.default_truncation)
+        if not isinstance(truncation, bool):
+            raise ValueError(f"truncation request parameter must be type bool")
+
         try:
             input_text = [
                 b.decode("utf-8") for b in input_text_tt.as_numpy().reshape(-1)
@@ -58,7 +80,10 @@ class TritonPythonModel:
 
         try:
             inputs = self.tokenizer(
-                text=input_text, padding="max_length", return_tensors="pt"
+                text=input_text,
+                padding="max_length",
+                truncation=truncation,
+                return_tensors="pt",
             )
             input_ids_np = inputs["input_ids"].numpy()
             attention_mask_np = inputs["attention_mask"].numpy()
@@ -69,7 +94,10 @@ class TritonPythonModel:
             # something that could severely impact performance
             if n_tokens > 512:
                 raise ValueError(
-                    f"Processing {input_text} has {n_tokens} tokens which exceeds max of 512."
+                    f"Processing {input_text} has {n_tokens} tokens which "
+                    "exceeds max of 512. You could try setting request parameter "
+                    "`truncation` to 'True' if you want to just use the first 512 "
+                    "tokens"
                 )
             for text in input_text:
                 if not (text.startswith("query: ") or text.startswith("passage: ")):

--- a/model-repository/e5_large_v2_tokenize/1/e5_large_v2_tokenize.py
+++ b/model-repository/e5_large_v2_tokenize/1/e5_large_v2_tokenize.py
@@ -30,9 +30,12 @@ class TritonPythonModel:
             self.default_truncation = False
         elif default_truncation in ["True", "true"]:
             self.default_truncation = True
+        elif default_truncation in ["longest_first", "only_first", "only_second", "do_not_truncate"]:
+            self.default_truncation = default_truncation
         else:
             raise ValueError(
-                f"{default_truncation=:} must be 'true' | 'True' | 'false' | 'False'"
+                f"{default_truncation=:} does not match "
+                "transformers.tokenizer.__call__ options"
             )
 
         self.tokenizer = AutoTokenizer.from_pretrained(
@@ -61,8 +64,6 @@ class TritonPythonModel:
         # Handle any request parameters
         request_params = json.loads(request.parameters())
         truncation = request_params.get("truncation", self.default_truncation)
-        if not isinstance(truncation, bool):
-            raise ValueError(f"truncation request parameter must be type bool")
 
         try:
             input_text = [

--- a/model-repository/e5_large_v2_tokenize/config.pbtxt
+++ b/model-repository/e5_large_v2_tokenize/config.pbtxt
@@ -27,6 +27,10 @@ parameters: [
     {
         key: "EXECUTION_ENV_PATH",
         value: {string_value: "$$TRITON_MODEL_DIRECTORY/e5_large_v2_tokenize.tar.gz"},
+    },
+    {
+        key: "default_truncation",
+        value: {string_value: "false"},
     }
 ]
 instance_group [

--- a/model-repository/embed_text/1/embed_text.py
+++ b/model-repository/embed_text/1/embed_text.py
@@ -34,9 +34,12 @@ class TritonPythonModel:
             self.default_truncation = False
         elif default_truncation in ["True", "true"]:
             self.default_truncation = True
+        elif default_truncation in ["longest_first", "only_first", "only_second", "do_not_truncate"]:
+            self.default_truncation = default_truncation
         else:
             raise ValueError(
-                f"{default_truncation=:} must be 'true' | 'True' | 'false' | 'False'"
+                f"{default_truncation=:} does not match "
+                "transformers.tokenizer.__call__ options"
             )
 
     async def execute(self, requests: list) -> list:
@@ -75,15 +78,6 @@ class TritonPythonModel:
                 responses[batch_id] = pb_utils.InferenceResponse(
                     error=pb_utils.TritonError(
                         f"{embed_model=:} not in {self.embed_models}"
-                    )
-                )
-                continue
-
-            if not isinstance(truncation, bool):
-                responses[batch_id] = pb_utils.InferenceResponse(
-                    error=pb_utils.TritonError(
-                        f"truncation request parameter type is {type(truncation)} "
-                        "must be type bool"
                     )
                 )
                 continue

--- a/model-repository/embed_text/config.pbtxt
+++ b/model-repository/embed_text/config.pbtxt
@@ -22,6 +22,10 @@ parameters: [
     {
         key: "default_embed_model",
         value: {string_value: "multilingual_e5_large"},
+    },
+    {
+        key: "default_truncation",
+        value: {string_value: "false"},
     }
 ]
 instance_group [

--- a/model-repository/multilingual_e5_large_tokenize/1/multilingual_e5_large_tokenize.py
+++ b/model-repository/multilingual_e5_large_tokenize/1/multilingual_e5_large_tokenize.py
@@ -30,10 +30,14 @@ class TritonPythonModel:
             self.default_truncation = False
         elif default_truncation in ["True", "true"]:
             self.default_truncation = True
+        elif default_truncation in ["longest_first", "only_first", "only_second", "do_not_truncate"]:
+            self.default_truncation = default_truncation
         else:
             raise ValueError(
-                f"{default_truncation=:} must be 'true' | 'True' | 'false' | 'False'"
+                f"{default_truncation=:} does not match "
+                "transformers.tokenizer.__call__ options"
             )
+
 
         self.tokenizer = AutoTokenizer.from_pretrained(
             "intfloat/multilingual-e5-large", local_files_only=True
@@ -61,8 +65,6 @@ class TritonPythonModel:
         # Handle any request parameters
         request_params = json.loads(request.parameters())
         truncation = request_params.get("truncation", self.default_truncation)
-        if not isinstance(truncation, bool):
-            raise ValueError(f"truncation request parameter must be type bool")
 
         try:
             input_text = [

--- a/model-repository/multilingual_e5_large_tokenize/config.pbtxt
+++ b/model-repository/multilingual_e5_large_tokenize/config.pbtxt
@@ -27,6 +27,10 @@ parameters: [
     {
         key: "EXECUTION_ENV_PATH",
         value: {string_value: "$$TRITON_MODEL_DIRECTORY/multilingual_e5_large_tokenize.tar.gz"},
+    },
+    {
+        key: "default_truncation",
+        value: {string_value: "false"},
     }
 ]
 instance_group [

--- a/model-repository/siglip_text_tokenize/1/siglip_text_tokenize.py
+++ b/model-repository/siglip_text_tokenize/1/siglip_text_tokenize.py
@@ -30,9 +30,12 @@ class TritonPythonModel:
             self.default_truncation = False
         elif default_truncation in ["True", "true"]:
             self.default_truncation = True
+        elif default_truncation in ["longest_first", "only_first", "only_second", "do_not_truncate"]:
+            self.default_truncation = default_truncation
         else:
             raise ValueError(
-                f"{default_truncation=:} must be 'true' | 'True' | 'false' | 'False'"
+                f"{default_truncation=:} does not match "
+                "transformers.tokenizer.__call__ options"
             )
 
         self.tokenizer = SiglipTokenizer.from_pretrained(
@@ -61,8 +64,6 @@ class TritonPythonModel:
         # Handle any request parameters
         request_params = json.loads(request.parameters())
         truncation = request_params.get("truncation", self.default_truncation)
-        if not isinstance(truncation, bool):
-            raise ValueError(f"truncation request parameter must be type bool")
 
         try:
             input_text = [

--- a/model-repository/siglip_text_tokenize/config.pbtxt
+++ b/model-repository/siglip_text_tokenize/config.pbtxt
@@ -22,6 +22,10 @@ parameters: [
     {
         key: "EXECUTION_ENV_PATH",
         value: {string_value: "$$TRITON_MODEL_DIRECTORY/siglip_text_tokenize.tar.gz"},
+    },
+    {
+        key: "default_truncation",
+        value: {string_value: "false"},
     }
 ]
 instance_group [


### PR DESCRIPTION
PR to add feature request in https://github.com/TritonsProngs/triton-embed-text/issues/3

This allows a user to provide the request parameter, truncation, that will be passed to the tokenizer of a given embedding model. The default is False. This preserves previous behavior and also ensures that a user doesn't quietly have their text truncated when making the embedding. Of course, this could greatly effect the performance.